### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@
 ## Installation Method 2 - Installing using archive
   * Download [ZIP Archive](https://github.com/)
   * Extract files
-  * In your Magento 2 root directory create folder app/code/Cybage/StorePickup
+  * In your Magento 2 root directory create folder app/code/Cybage/Storepickup
   * Copy files and folders from archive to that folder
   * In command line, using "cd", navigate to your Magento 2 root directory
   * Run commands:


### PR DESCRIPTION
The manual installation instructions ("Method 2") incorrectly states to create the directory "StorePickup" where "Storepickup" is expected. This incorrect namespacing causes a number of issues related to extension installation and operation.